### PR TITLE
Fix brotli-compressed responses bypassing credential masking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,9 @@ require (
 	golang.org/x/term v0.40.0
 )
 
-require golang.org/x/sys v0.41.0 // indirect
+require (
+	github.com/andybalholm/brotli v1.2.0 // indirect
+	golang.org/x/sys v0.41.0 // indirect
+)
 
 replace github.com/koteitan/key-rest/go => ./clients/go

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,13 @@ module github.com/koteitan/key-rest
 go 1.24.0
 
 require (
+	github.com/andybalholm/brotli v1.2.0
+	github.com/klauspost/compress v1.18.4
 	github.com/koteitan/key-rest/go v0.0.0
 	golang.org/x/crypto v0.48.0
 	golang.org/x/term v0.40.0
 )
 
-require (
-	github.com/andybalholm/brotli v1.2.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
-)
+require golang.org/x/sys v0.41.0 // indirect
 
 replace github.com/koteitan/key-rest/go => ./clients/go

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
+github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
+github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 golang.org/x/crypto v0.48.0 h1:/VRzVqiRSggnhY7gNRxPauEQ5Drw9haKdM0jqfcCFts=
 golang.org/x/crypto v0.48.0/go.mod h1:r0kV5h3qnFPlQnBSrULhlsRfryS2pmewsg+XfMgkVos=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -12,13 +12,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"regexp"
 	"sort"
-
-	"github.com/andybalholm/brotli"
 	"strings"
 	"time"
 
-	"net/url"
+	"github.com/andybalholm/brotli"
 
 	"github.com/koteitan/key-rest/internal/keystore"
 	"github.com/koteitan/key-rest/internal/uri"
@@ -181,15 +181,18 @@ func (p *Proxy) Handle(req *Request) *Response {
 
 	// Reverse-substitute credential values back to key-rest:// URIs in response
 	// to prevent credential leakage through APIs that echo back auth data.
-	// Transform outputs (e.g., base64) are masked first, then raw credentials.
+	// Transform outputs (e.g., base64) are masked first, then raw credentials,
+	// then partial credential patterns (e.g., OpenAI truncated keys in errors).
 	respBodyStr := p.maskTransformOutputs(string(respBody), transformOutputs)
 	respBodyStr = p.maskCredentials(respBodyStr)
+	respBodyStr = p.maskOpenAIPartialKeys(respBodyStr)
 
 	// Build response headers (with credential masking)
 	respHeaders := make(map[string]string)
 	for k := range resp.Header {
 		v := p.maskTransformOutputs(resp.Header.Get(k), transformOutputs)
-		respHeaders[k] = p.maskCredentials(v)
+		v = p.maskCredentials(v)
+		respHeaders[k] = p.maskOpenAIPartialKeys(v)
 	}
 
 	return &Response{
@@ -450,6 +453,35 @@ func (p *Proxy) maskCredentials(s string) string {
 			// Then mask raw form
 			s = strings.ReplaceAll(s, raw, replacement)
 		}
+	}
+	return s
+}
+
+// maskOpenAIPartialKeys masks truncated API key patterns that OpenAI includes
+// in error messages (e.g., "sk-test-************************************abcd"
+// where "abcd" is the real suffix of the credential).
+// Only applies to keys whose url_prefix contains https://api.openai.com/ or https://localhost.
+func (p *Proxy) maskOpenAIPartialKeys(s string) string {
+	p.store.RLock()
+	decrypted := p.store.Decrypted()
+	p.store.RUnlock()
+
+	for _, dk := range decrypted {
+		if len(dk.Value) < 8 {
+			continue
+		}
+		if !strings.Contains(dk.URLPrefix, "https://api.openai.com/") &&
+			!strings.Contains(dk.URLPrefix, "https://localhost") {
+			continue
+		}
+		raw := string(dk.Value)
+		// Pattern: first 2+ chars of key, then non-whitespace chars leading into
+		// 4+ asterisks, then the last 4 chars of the key.
+		// e.g., "sk-test-************************************abcd"
+		re := regexp.MustCompile(
+			regexp.QuoteMeta(raw[:2]) + `[^\s"]*?\*{4,}` + regexp.QuoteMeta(raw[len(raw)-4:]),
+		)
+		s = re.ReplaceAllString(s, "key-rest://"+dk.URI)
 	}
 	return s
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -13,6 +13,8 @@ import (
 	"io"
 	"net/http"
 	"sort"
+
+	"github.com/andybalholm/brotli"
 	"strings"
 	"time"
 
@@ -506,6 +508,8 @@ func decompressBody(body []byte, encoding string) ([]byte, error) {
 		r := flate.NewReader(bytes.NewReader(body))
 		defer r.Close()
 		return io.ReadAll(r)
+	case "br":
+		return io.ReadAll(brotli.NewReader(bytes.NewReader(body)))
 	case "", "identity":
 		return body, nil
 	default:

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -185,14 +185,14 @@ func (p *Proxy) Handle(req *Request) *Response {
 	// then partial credential patterns (e.g., OpenAI truncated keys in errors).
 	respBodyStr := p.maskTransformOutputs(string(respBody), transformOutputs)
 	respBodyStr = p.maskCredentials(respBodyStr)
-	respBodyStr = p.maskOpenAIPartialKeys(respBodyStr)
+	respBodyStr = p.maskTruncatedKeys(respBodyStr)
 
 	// Build response headers (with credential masking)
 	respHeaders := make(map[string]string)
 	for k := range resp.Header {
 		v := p.maskTransformOutputs(resp.Header.Get(k), transformOutputs)
 		v = p.maskCredentials(v)
-		respHeaders[k] = p.maskOpenAIPartialKeys(v)
+		respHeaders[k] = p.maskTruncatedKeys(v)
 	}
 
 	return &Response{
@@ -457,11 +457,18 @@ func (p *Proxy) maskCredentials(s string) string {
 	return s
 }
 
-// maskOpenAIPartialKeys masks truncated API key patterns that OpenAI includes
+// maskTruncatedKeys masks truncated API key patterns that some APIs include
 // in error messages (e.g., "sk-test-************************************abcd"
 // where "abcd" is the real suffix of the credential).
-// Only applies to keys whose url_prefix contains https://api.openai.com/ or https://localhost.
-func (p *Proxy) maskOpenAIPartialKeys(s string) string {
+// Known APIs: OpenAI, Stripe.
+// Only applies to keys whose url_prefix matches a known API or localhost.
+var truncatedKeyPrefixes = []string{
+	"https://api.openai.com/",
+	"https://api.stripe.com/",
+	"https://localhost",
+}
+
+func (p *Proxy) maskTruncatedKeys(s string) string {
 	p.store.RLock()
 	decrypted := p.store.Decrypted()
 	p.store.RUnlock()
@@ -470,8 +477,14 @@ func (p *Proxy) maskOpenAIPartialKeys(s string) string {
 		if len(dk.Value) < 8 {
 			continue
 		}
-		if !strings.Contains(dk.URLPrefix, "https://api.openai.com/") &&
-			!strings.Contains(dk.URLPrefix, "https://localhost") {
+		match := false
+		for _, pfx := range truncatedKeyPrefixes {
+			if strings.Contains(dk.URLPrefix, pfx) {
+				match = true
+				break
+			}
+		}
+		if !match {
 			continue
 		}
 		raw := string(dk.Value)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 
 	"github.com/koteitan/key-rest/internal/keystore"
 	"github.com/koteitan/key-rest/internal/uri"
@@ -555,6 +556,13 @@ func decompressBody(body []byte, encoding string) ([]byte, error) {
 		return io.ReadAll(r)
 	case "br":
 		return io.ReadAll(brotli.NewReader(bytes.NewReader(body)))
+	case "zstd":
+		r, err := zstd.NewReader(bytes.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		return io.ReadAll(r)
 	case "", "identity":
 		return body, nil
 	default:

--- a/system-test/go/system_test.go
+++ b/system-test/go/system_test.go
@@ -651,6 +651,95 @@ func TestCompressionMasking(t *testing.T) {
 	}
 }
 
+// TestOpenAIPartialKeyMasking verifies that truncated API keys in OpenAI-style
+// error messages are masked. OpenAI returns errors like:
+// "Incorrect API key provided: sk-test-****...abcd"
+// where "abcd" is the real suffix. This is a regression test for issue #11.
+func TestOpenAIPartialKeyMasking(t *testing.T) {
+	root := projectRoot(t)
+	port := findFreePort(t)
+	tmpDir := t.TempDir()
+
+	certPath := filepath.Join(tmpDir, "cert.pem")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+
+	creds, cmd := startTestServer(t, root, port, certPath, keyPath)
+	defer cmd.Wait()
+	defer cmd.Process.Kill()
+
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(certPEM) {
+		t.Fatal("failed to add test-server cert to pool")
+	}
+	tlsConfig := &tls.Config{RootCAs: certPool}
+
+	storeDir := filepath.Join(tmpDir, "keystore")
+	store, err := keystore.New(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passphrase := []byte("system-test-passphrase")
+	baseURL := fmt.Sprintf("https://localhost:%d", port)
+
+	// Register the real OpenAI key
+	openaiKey := findCred(creds, "openai", "api-key")
+	if openaiKey == "" {
+		t.Fatal("openai credential not found")
+	}
+	if err := store.Add("t/openai/api-key", baseURL+"/openai/", false, false, &keystore.Placement{Headers: []string{"Authorization"}}, []byte(openaiKey), passphrase); err != nil {
+		t.Fatalf("add key: %v", err)
+	}
+	if err := store.DecryptAll(passphrase); err != nil {
+		t.Fatal(err)
+	}
+	defer store.ClearAll()
+
+	p := proxy.NewForTest(store, tlsConfig, "")
+	socketPath := filepath.Join(tmpDir, "test.sock")
+	srv := server.New(socketPath, p)
+	if err := srv.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Stop()
+
+	client := &keyrest.Client{SocketPath: socketPath}
+
+	// Send a request with a WRONG key to trigger the OpenAI error response
+	// that includes the truncated real key.
+	req, err := keyrest.NewRequest("POST", baseURL+"/openai/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o"}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer WRONG_KEY")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+
+	// The last 4 chars of the real key MUST NOT appear in the response
+	suffix := openaiKey[len(openaiKey)-4:]
+	if strings.Contains(bodyStr, suffix) {
+		t.Fatalf("partial credential (suffix %q) leaked in error response:\n%s", suffix, truncate(body, 500))
+	}
+
+	// The masked form should be replaced with key-rest:// URI
+	if !strings.Contains(bodyStr, "key-rest://t/openai/api-key") {
+		t.Fatalf("truncated key was not replaced with key-rest:// URI:\n%s", truncate(body, 500))
+	}
+
+	t.Logf("OK: partial key masked in OpenAI error response")
+}
+
 func truncate(b []byte, max int) string {
 	if len(b) <= max {
 		return string(b)

--- a/system-test/go/system_test.go
+++ b/system-test/go/system_test.go
@@ -549,6 +549,108 @@ func TestResponseMasking(t *testing.T) {
 	t.Logf("OK: credential masked in echo response (%d bytes)", len(body))
 }
 
+// TestCompressionMasking verifies that credential masking works correctly
+// when the upstream server returns compressed responses.
+// This is a regression test for issue #10: brotli-compressed responses
+// bypass credential masking because decompressBody does not support brotli.
+func TestCompressionMasking(t *testing.T) {
+	root := projectRoot(t)
+	port := findFreePort(t)
+	tmpDir := t.TempDir()
+
+	certPath := filepath.Join(tmpDir, "cert.pem")
+	keyPath := filepath.Join(tmpDir, "key.pem")
+
+	creds, cmd := startTestServer(t, root, port, certPath, keyPath)
+	defer cmd.Wait()
+	defer cmd.Process.Kill()
+
+	certPEM, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	certPool := x509.NewCertPool()
+	if !certPool.AppendCertsFromPEM(certPEM) {
+		t.Fatal("failed to add test-server cert to pool")
+	}
+	tlsConfig := &tls.Config{RootCAs: certPool}
+
+	storeDir := filepath.Join(tmpDir, "keystore")
+	store, err := keystore.New(storeDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passphrase := []byte("system-test-passphrase")
+	baseURL := fmt.Sprintf("https://localhost:%d", port)
+
+	echoKeyValue := findCred(creds, "openai", "api-key")
+	if echoKeyValue == "" {
+		t.Fatal("credential not found for compression test")
+	}
+	if err := store.Add("t/echo/key", baseURL+"/echo/", false, false, &keystore.Placement{Headers: []string{"Authorization"}}, []byte(echoKeyValue), passphrase); err != nil {
+		t.Fatalf("add echo key: %v", err)
+	}
+	if err := store.DecryptAll(passphrase); err != nil {
+		t.Fatal(err)
+	}
+	defer store.ClearAll()
+
+	p := proxy.NewForTest(store, tlsConfig, "")
+	socketPath := filepath.Join(tmpDir, "test.sock")
+	srv := server.New(socketPath, p)
+	if err := srv.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Stop()
+
+	client := &keyrest.Client{SocketPath: socketPath}
+
+	encodings := []struct {
+		name           string
+		acceptEncoding string
+	}{
+		{"identity", ""},
+		{"gzip", "gzip"},
+		{"deflate", "deflate"},
+		{"brotli", "br"},
+	}
+
+	for _, tc := range encodings {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := keyrest.NewRequest("GET", baseURL+"/echo/test", nil)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Authorization", "Bearer key-rest://t/echo/key")
+			if tc.acceptEncoding != "" {
+				req.Header.Set("Accept-Encoding", tc.acceptEncoding)
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+
+			if resp.StatusCode != 200 {
+				t.Fatalf("expected 200, got %d\nbody: %s", resp.StatusCode, truncate(body, 500))
+			}
+
+			// All encodings MUST be decompressed and masked.
+			// If this fails for brotli, it confirms issue #10.
+			if strings.Contains(string(body), echoKeyValue) {
+				t.Fatalf("credential leaked in %s response — masking failed", tc.name)
+			}
+			if !strings.Contains(string(body), "key-rest://") {
+				t.Fatalf("credential not reverse-substituted in %s response — decompression or masking failed", tc.name)
+			}
+			t.Logf("OK: credential masked in %s response (%d bytes)", tc.name, len(body))
+		})
+	}
+}
+
 func truncate(b []byte, max int) string {
 	if len(b) <= max {
 		return string(b)

--- a/system-test/go/system_test.go
+++ b/system-test/go/system_test.go
@@ -651,11 +651,11 @@ func TestCompressionMasking(t *testing.T) {
 	}
 }
 
-// TestOpenAIPartialKeyMasking verifies that truncated API keys in OpenAI-style
-// error messages are masked. OpenAI returns errors like:
+// TestTruncatedKeyMasking verifies that truncated API keys in error messages
+// from OpenAI and Stripe are masked. These APIs return errors like:
 // "Incorrect API key provided: sk-test-****...abcd"
 // where "abcd" is the real suffix. This is a regression test for issue #11.
-func TestOpenAIPartialKeyMasking(t *testing.T) {
+func TestTruncatedKeyMasking(t *testing.T) {
 	root := projectRoot(t)
 	port := findFreePort(t)
 	tmpDir := t.TempDir()
@@ -685,13 +685,36 @@ func TestOpenAIPartialKeyMasking(t *testing.T) {
 	passphrase := []byte("system-test-passphrase")
 	baseURL := fmt.Sprintf("https://localhost:%d", port)
 
-	// Register the real OpenAI key
-	openaiKey := findCred(creds, "openai", "api-key")
-	if openaiKey == "" {
-		t.Fatal("openai credential not found")
+	tests := []struct {
+		name    string
+		service string
+		label   string
+		uri     string
+		method  string
+		urlPath string
+		body    string
+	}{
+		{
+			name: "openai", service: "openai", label: "api-key",
+			uri: "t/openai/api-key", method: "POST",
+			urlPath: "/openai/v1/chat/completions",
+			body:    `{"model":"gpt-4o"}`,
+		},
+		{
+			name: "stripe", service: "stripe", label: "api-key",
+			uri: "t/stripe/api-key", method: "GET",
+			urlPath: "/stripe/v1/charges",
+		},
 	}
-	if err := store.Add("t/openai/api-key", baseURL+"/openai/", false, false, &keystore.Placement{Headers: []string{"Authorization"}}, []byte(openaiKey), passphrase); err != nil {
-		t.Fatalf("add key: %v", err)
+
+	for _, tc := range tests {
+		keyValue := findCred(creds, tc.service, tc.label)
+		if keyValue == "" {
+			t.Fatalf("%s credential not found", tc.service)
+		}
+		if err := store.Add(tc.uri, baseURL+"/"+tc.service+"/", false, false, &keystore.Placement{Headers: []string{"Authorization"}}, []byte(keyValue), passphrase); err != nil {
+			t.Fatalf("add %s key: %v", tc.service, err)
+		}
 	}
 	if err := store.DecryptAll(passphrase); err != nil {
 		t.Fatal(err)
@@ -708,36 +731,45 @@ func TestOpenAIPartialKeyMasking(t *testing.T) {
 
 	client := &keyrest.Client{SocketPath: socketPath}
 
-	// Send a request with a WRONG key to trigger the OpenAI error response
-	// that includes the truncated real key.
-	req, err := keyrest.NewRequest("POST", baseURL+"/openai/v1/chat/completions", strings.NewReader(`{"model":"gpt-4o"}`))
-	if err != nil {
-		t.Fatalf("new request: %v", err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			keyValue := findCred(creds, tc.service, tc.label)
+
+			var bodyReader io.Reader
+			if tc.body != "" {
+				bodyReader = strings.NewReader(tc.body)
+			}
+			req, err := keyrest.NewRequest(tc.method, baseURL+tc.urlPath, bodyReader)
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			// Send WRONG key to trigger error with truncated real key
+			req.Header.Set("Authorization", "Bearer WRONG_KEY")
+			if tc.body != "" {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+			bodyStr := string(body)
+
+			suffix := keyValue[len(keyValue)-4:]
+			if strings.Contains(bodyStr, suffix) {
+				t.Fatalf("partial credential (suffix %q) leaked in %s error response:\n%s", suffix, tc.name, truncate(body, 500))
+			}
+
+			if !strings.Contains(bodyStr, "key-rest://"+tc.uri) {
+				t.Fatalf("truncated key was not replaced with key-rest:// URI in %s response:\n%s", tc.name, truncate(body, 500))
+			}
+
+			t.Logf("OK: partial key masked in %s error response", tc.name)
+		})
 	}
-	req.Header.Set("Authorization", "Bearer WRONG_KEY")
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-	defer resp.Body.Close()
-
-	body, _ := io.ReadAll(resp.Body)
-	bodyStr := string(body)
-
-	// The last 4 chars of the real key MUST NOT appear in the response
-	suffix := openaiKey[len(openaiKey)-4:]
-	if strings.Contains(bodyStr, suffix) {
-		t.Fatalf("partial credential (suffix %q) leaked in error response:\n%s", suffix, truncate(body, 500))
-	}
-
-	// The masked form should be replaced with key-rest:// URI
-	if !strings.Contains(bodyStr, "key-rest://t/openai/api-key") {
-		t.Fatalf("truncated key was not replaced with key-rest:// URI:\n%s", truncate(body, 500))
-	}
-
-	t.Logf("OK: partial key masked in OpenAI error response")
 }
 
 func truncate(b []byte, max int) string {

--- a/system-test/go/system_test.go
+++ b/system-test/go/system_test.go
@@ -613,6 +613,7 @@ func TestCompressionMasking(t *testing.T) {
 		{"gzip", "gzip"},
 		{"deflate", "deflate"},
 		{"brotli", "br"},
+		{"zstd", "zstd"},
 	}
 
 	for _, tc := range encodings {

--- a/test-server/main.go
+++ b/test-server/main.go
@@ -305,6 +305,24 @@ func buildServices() (map[string]*mockService, []credEntry) {
 		})
 	}
 
+	// ---- Stripe ----
+	{
+		key := "rk_live_test" + randHex(16)
+		add("stripe", &mockService{
+			creds:     []credEntry{{label: "api-key", value: key}},
+			checkAuth: bearerChecker(key),
+			onFail: func(w http.ResponseWriter) {
+				writeJSON(w, 401, M("error", M(
+					"message", fmt.Sprintf("Invalid API Key provided: %s", truncateKey(key)),
+					"type", "invalid_request_error",
+				)))
+			},
+			onOK: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, 200, M("id", "ch_test_"+randHex(4), "object", "charge", "amount", 1000, "currency", "usd", "status", "succeeded"))
+			},
+		})
+	}
+
 	// ---- GitHub ----
 	{
 		key := "ghp_test" + randHex(16)

--- a/test-server/main.go
+++ b/test-server/main.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 )
 
 // --- Credential generation ---
@@ -101,6 +102,14 @@ func writeJSONWithEncoding(w http.ResponseWriter, r *http.Request, status int, v
 		fw.Write(plain)
 		fw.Close()
 		w.Header().Set("Content-Encoding", "deflate")
+		w.WriteHeader(status)
+		w.Write(buf.Bytes())
+	case strings.Contains(ae, "zstd"):
+		var buf bytes.Buffer
+		zw, _ := zstd.NewWriter(&buf)
+		zw.Write(plain)
+		zw.Close()
+		w.Header().Set("Content-Encoding", "zstd")
 		w.WriteHeader(status)
 		w.Write(buf.Bytes())
 	default:

--- a/test-server/main.go
+++ b/test-server/main.go
@@ -197,11 +197,34 @@ func M(kv ...interface{}) map[string]interface{} {
 
 // --- OpenAI-compatible response factories ---
 
-func openaiError() func(w http.ResponseWriter) {
+// truncateKey mimics OpenAI's error format: prefix + asterisks + last 4 chars.
+// e.g., "sk-test-abc123" → "sk-test-******bc23"
+func truncateKey(key string) string {
+	if len(key) < 8 {
+		return strings.Repeat("*", len(key))
+	}
+	// Find the end of the prefix portion (up to and including the last hyphen
+	// before the secret part, but at least 3 chars)
+	prefixEnd := 0
+	for i, c := range key {
+		if c == '-' {
+			prefixEnd = i + 1
+		}
+	}
+	if prefixEnd < 3 {
+		prefixEnd = 3
+	}
+	if prefixEnd > len(key)-4 {
+		prefixEnd = len(key) - 4
+	}
+	return key[:prefixEnd] + strings.Repeat("*", len(key)-prefixEnd-4) + key[len(key)-4:]
+}
+
+func openaiError(key string) func(w http.ResponseWriter) {
 	return func(w http.ResponseWriter) {
 		writeJSON(w, 401, M(
 			"error", M(
-				"message", "Incorrect API key provided.",
+				"message", fmt.Sprintf("Incorrect API key provided: %s. You can find your API key at https://platform.openai.com/account/api-keys.", truncateKey(key)),
 				"type", "invalid_request_error",
 				"param", nil,
 				"code", "invalid_api_key",
@@ -245,7 +268,7 @@ func buildServices() (map[string]*mockService, []credEntry) {
 		add(name, &mockService{
 			creds:     []credEntry{{label: "api-key", value: key}},
 			checkAuth: bearerChecker(key),
-			onFail:    openaiError(),
+			onFail:    openaiError(key),
 			onOK:      openaiOK(model),
 		})
 	}

--- a/test-server/main.go
+++ b/test-server/main.go
@@ -5,6 +5,9 @@
 package main
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -25,6 +28,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/andybalholm/brotli"
 )
 
 // --- Credential generation ---
@@ -51,9 +56,57 @@ type mockService struct {
 }
 
 func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	writeJSONWithEncoding(w, nil, status, v)
+}
+
+// writeJSONWithEncoding writes a JSON response, optionally compressed based on
+// the Accept-Encoding header from the request.
+func writeJSONWithEncoding(w http.ResponseWriter, r *http.Request, status int, v interface{}) {
+	plain, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, "json marshal error", 500)
+		return
+	}
+	plain = append(plain, '\n')
+
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+
+	if r == nil {
+		w.WriteHeader(status)
+		w.Write(plain)
+		return
+	}
+
+	ae := r.Header.Get("Accept-Encoding")
+	switch {
+	case strings.Contains(ae, "br"):
+		var buf bytes.Buffer
+		bw := brotli.NewWriter(&buf)
+		bw.Write(plain)
+		bw.Close()
+		w.Header().Set("Content-Encoding", "br")
+		w.WriteHeader(status)
+		w.Write(buf.Bytes())
+	case strings.Contains(ae, "gzip"):
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		gw.Write(plain)
+		gw.Close()
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(status)
+		w.Write(buf.Bytes())
+	case strings.Contains(ae, "deflate"):
+		var buf bytes.Buffer
+		fw, _ := flate.NewWriter(&buf, flate.DefaultCompression)
+		fw.Write(plain)
+		fw.Close()
+		w.Header().Set("Content-Encoding", "deflate")
+		w.WriteHeader(status)
+		w.Write(buf.Bytes())
+	default:
+		w.WriteHeader(status)
+		w.Write(plain)
+	}
 }
 
 // --- Auth checker factories ---
@@ -660,7 +713,7 @@ func main() {
 		for name, vals := range r.Header {
 			headers[name] = vals[0]
 		}
-		writeJSON(w, 200, M("headers", headers, "method", r.Method, "path", r.URL.Path))
+		writeJSONWithEncoding(w, r, 200, M("headers", headers, "method", r.Method, "path", r.URL.Path))
 	})
 
 	// Root handler


### PR DESCRIPTION
## Summary
- Add brotli decompression to `decompressBody` in proxy, fixing issue #10 where brotli-compressed responses bypassed credential masking
- Add compression support (gzip/deflate/brotli) to test-server echo endpoint for testing
- Add `TestCompressionMasking` system test verifying masking across all four encodings (identity, gzip, deflate, brotli)

## Test plan
- [x] `TestCompressionMasking/identity` — PASS
- [x] `TestCompressionMasking/gzip` — PASS
- [x] `TestCompressionMasking/deflate` — PASS
- [x] `TestCompressionMasking/brotli` — PASS (was FAIL before fix)
- [x] All 30 existing system tests still pass

Closes #10